### PR TITLE
Prepare support library to upload to bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,21 @@ The code generator requires ruby version 2.1 or later.
 It is recommended to use [bundler](http://bundler.io/) to install
 the code generators ruby package.
 
-Until this project is released, it is recommended to include it into
-a project as a git submodule.
-
-    $ git submodule https://github.com/Shopify/graphql_java_gen.git
-
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'graphql_java_gen', path: 'graphql_java_gen'
+gem 'graphql_java_gen'
 ```
 
 And then execute:
 
     $ bundle
 
-The generated code depends on the com.shopify.graphql.support package
-which is in the support directory of this repo. Create a symlink to
-include that project in a [gradle multi-project build
-](https://docs.gradle.org/current/userguide/multi_project_builds.html)
+The generated code depends on the com.shopify.graphql.support java
+package. This can be added to a gradle project by adding the following
+jCenter dependancy to you `build.gradle` file:
 
-    $ ln -s graphql_java_gen/support GraphQLSupport
+    compile 'com.shopify.graphql.support:graphql-support:0.1.0'
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The generated code depends on the com.shopify.graphql.support java
 package. This can be added to a gradle project by adding the following
 jCenter dependancy to you `build.gradle` file:
 
-    compile 'com.shopify.graphql.support:graphql-support:0.1.0'
+    compile 'com.shopify.graphql.support:support:0.1.0'
 
 ## Usage
 

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,8 +1,20 @@
+def VERSION_NAME = '0.1.0'
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+    }
+}
+
 repositories {
     jcenter()
 }
 
 apply plugin: 'java'
+apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     compile 'com.google.code.gson:gson:2.7'
@@ -22,5 +34,46 @@ compileTestJava {
 test {
     testLogging {
         exceptionFormat = 'full'
+    }
+}
+
+version = VERSION_NAME
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+bintray {
+    /*
+    These values can be found on https://bintray.com/profile/edit
+    BINTRAY_USER : your personal profile name (from "Your Profile")
+    BINTRAY_KEY : found on the left menu, under "API Key"
+     */
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+
+    configurations = ['archives']
+    pkg {
+        userOrg = 'shopify'
+        repo = 'shopify-java'
+        name = 'graphql-support'
+        desc = 'GraphQL support package generated client code'
+        websiteUrl = 'https://github.com/Shopify/graphql_java_gen'
+        vcsUrl = 'https://github.com/Shopify/graphql_java_gen.git'
+        licenses = ['MIT']
+        version {
+            name = VERSION_NAME
+        }
     }
 }

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 apply plugin: 'java'
+apply plugin: 'maven'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
@@ -54,6 +55,52 @@ artifacts {
     archives sourcesJar
 }
 
+ext {
+    publishedGroupId = 'com.shopify.graphql.support'
+    artifact = 'support'
+    libraryName = 'graphql-support'
+
+    libraryDescription = 'GraphQL support package generated client code'
+
+    siteUrl = 'https://github.com/Shopify/graphql_java_gen'
+    gitUrl = 'https://github.com/Shopify/graphql_java_gen.git'
+
+    licenseName = 'The MIT License'
+    licenseUrl = 'https://opensource.org/licenses/MIT'
+    allLicenses = ["MIT"]
+}
+
+group = publishedGroupId
+
+install {
+    repositories.mavenInstaller {
+        // Generates POM.xml with proper parameters
+        pom {
+            project {
+                groupId publishedGroupId
+                artifactId artifact
+
+                name libraryName
+                description libraryDescription
+                url siteUrl
+
+                licenses {
+                    license {
+                        name licenseName
+                        url licenseUrl
+                    }
+                }
+
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+                }
+            }
+        }
+    }
+}
+
 bintray {
     /*
     These values can be found on https://bintray.com/profile/edit
@@ -64,14 +111,15 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
 
     configurations = ['archives']
+    publish = true
     pkg {
         userOrg = 'shopify'
         repo = 'shopify-java'
-        name = 'graphql-support'
-        desc = 'GraphQL support package generated client code'
-        websiteUrl = 'https://github.com/Shopify/graphql_java_gen'
-        vcsUrl = 'https://github.com/Shopify/graphql_java_gen.git'
-        licenses = ['MIT']
+        name = libraryName
+        desc = libraryDescription
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = allLicenses
         version {
             name = VERSION_NAME
         }


### PR DESCRIPTION
Currently using the library requires using it through a git submodule.

I think this adds what is needed to upload the package to bintray so that only

    compile 'com.shopify.graphql.support:graphql-support:0.1.0'

needs to be added to gradle.build to use it.