### PR TITLE
Revert "Only insert a null check if the field is nullable"

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -208,9 +208,7 @@ public class <%= schema_name %> {
                     <% end %>
                     <% type.fields.each do |field| %>
                       <% next unless field.type.unwrap.object? %>
-                      <% unless field.type.non_null? %>
-                        if (get<%= field.classify_name %>() != null) {
-                      <% end %>
+                      if (get<%= field.classify_name %>() != null) {
                         <% if field.type.unwrap_non_null.kind == 'LIST' %>
                             for (<%= java_output_type(field.type.unwrap) %> elem: get<%= field.classify_name %>()) {
                               children.addAll(elem.getNodes());
@@ -218,9 +216,7 @@ public class <%= schema_name %> {
                         <% else %>
                             children.addAll(get<%= field.classify_name %>().getNodes());
                         <% end %>
-                      <% unless field.type.non_null? %>
-                        }
-                      <% end %>
+                      }
                     <% end %>
                     return children;
                   }


### PR DESCRIPTION
Reverts Shopify/graphql_java_gen#10

This was dumb, sorry. Even if the field is non-null it might not have been requested.