### PR TITLE
Add a base node interface for relay schemas

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -155,7 +155,11 @@ public class <%= schema_name %> {
             }
 
             <% unless type.object? %>
-                public interface <%= type.name %> {
+                <% if type.name == 'Node' %>
+                  public interface <%= type.name %> extends com.shopify.graphql.support.Node {
+                <% else %>
+                  public interface <%= type.name %> {
+                <% end %>
                     String getGraphQlTypeName();
                     <% type.fields.each do |field| %>
                         <%= java_output_type(field.type) %> get<%= field.classify_name %>();
@@ -201,8 +205,8 @@ public class <%= schema_name %> {
                 <% end %>
 
                 <% if type_names_set.include?('Node') %>
-                  public List<Node> getNodes() {
-                    List<Node> children = new ArrayList<>();
+                  public List<com.shopify.graphql.support.Node> getNodes() {
+                    List<com.shopify.graphql.support.Node> children = new ArrayList<>();
                     <% if type.object? && type.implement?("Node") %>
                       children.add(this);
                     <% end %>

--- a/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -5,7 +5,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Created by dylansmith on 2015-11-23.
@@ -95,6 +97,10 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
             throw new SchemaViolationError(this, field, element);
         }
         return element.getAsJsonArray();
+    }
+
+    public List<Node> getNodes() {
+        return new ArrayList<>();
     }
 
     public abstract boolean unwrapsToObject(String key);

--- a/support/src/main/java/com/shopify/graphql/support/Node.java
+++ b/support/src/main/java/com/shopify/graphql/support/Node.java
@@ -1,0 +1,8 @@
+package com.shopify.graphql.support;
+
+// Helpful to have this common base class for Relay-compatible schemas. Unused otherwise.
+public interface Node {
+    String getGraphQlTypeName();
+
+    ID getId();
+}


### PR DESCRIPTION
Define a basic `Node` interface for use by relay-compatible schemas in
the support package. This lets `AbstractResponse` declare the
appropriate `getNodes` method.

@dylanahsmith 

Fixes #11.