### PR TITLE
Add interface fields to getNodes

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -161,6 +161,7 @@ public class <%= schema_name %> {
                   public interface <%= type.name %> {
                 <% end %>
                     String getGraphQlTypeName();
+                    AbstractResponse self();
                     <% type.fields.each do |field| %>
                         <%= java_output_type(field.type) %> get<%= field.classify_name %>();
                     <% end %>
@@ -211,14 +212,14 @@ public class <%= schema_name %> {
                       children.add(this);
                     <% end %>
                     <% type.fields.each do |field| %>
-                      <% next unless field.type.unwrap.object? %>
+                      <% next unless field.type.unwrap.object? || field.type.unwrap.interface? %>
                       if (get<%= field.classify_name %>() != null) {
                         <% if field.type.unwrap_non_null.kind == 'LIST' %>
                             for (<%= java_output_type(field.type.unwrap) %> elem: get<%= field.classify_name %>()) {
-                              children.addAll(elem.getNodes());
+                              children.addAll(elem.self().getNodes());
                             }
                         <% else %>
-                            children.addAll(get<%= field.classify_name %>().getNodes());
+                            children.addAll(get<%= field.classify_name %>().self().getNodes());
                         <% end %>
                       }
                     <% end %>

--- a/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -103,5 +103,9 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
         return new ArrayList<>();
     }
 
+    public AbstractResponse self() {
+        return this;
+    }
+
     public abstract boolean unwrapsToObject(String key);
 }


### PR DESCRIPTION
Previously we were not traversing interface fields in the generated
getNodes implementations, while we should.

It wasn't quite as simple as adjusting the condition though, because
while all interfaces are implemented by concrete types extending from
AbstractResponse, the java type system cannot represent the concept of
an interface extending a class. Add a self() method to AbstractResponse
and put it in each generated interface to solve.

I suppose an alternative might be to make AbstractResponse an interface
itself and then have a ConcreteAbstractResponse implements
AbstractResponse or something like that.

Thoughts?

@dylanahsmith @DanielJette 