### PR TITLE
Implement getNode dynamically

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -204,28 +204,6 @@ public class <%= schema_name %> {
                     }
                 <% end %>
 
-                <% if type_names_set.include?('Node') %>
-                  public List<com.shopify.graphql.support.Node> getNodes() {
-                    List<com.shopify.graphql.support.Node> children = new ArrayList<>();
-                    <% if type.object? && type.implement?("Node") %>
-                      children.add(this);
-                    <% end %>
-                    <% type.fields.each do |field| %>
-                      <% next unless field.type.unwrap.object? %>
-                      if (get<%= field.classify_name %>() != null) {
-                        <% if field.type.unwrap_non_null.kind == 'LIST' %>
-                            for (<%= java_output_type(field.type.unwrap) %> elem: get<%= field.classify_name %>()) {
-                              children.addAll(elem.getNodes());
-                            }
-                        <% else %>
-                            children.addAll(get<%= field.classify_name %>().getNodes());
-                        <% end %>
-                      }
-                    <% end %>
-                    return children;
-                  }
-                <% end %>
-
                 <% if type.object? %>
                     public String getGraphQlTypeName() {
                         return "<%= type.name %>";

--- a/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -100,22 +100,24 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
     }
 
     public List<Node> getNodes() {
-        ArrayList<Node> children = new ArrayList<>();
+        final ArrayList<Node> children = new ArrayList<>();
 
-        if (this instanceof Node) {
-            children.add((Node) this);
-        }
-
-        for (String key : responseData.keySet()) {
-            collectNodes(get(key), children);
-        }
+        collectNodes(this, children);
 
         return children;
     }
 
-    private void collectNodes(Object o, List<Node> collection) {
+    private static void collectNodes(Object o, List<Node> collection) {
         if (o instanceof AbstractResponse) {
-            collection.addAll(((AbstractResponse) o).getNodes());
+            final AbstractResponse response = (AbstractResponse) o;
+
+            if (response instanceof Node) {
+                collection.add((Node) response);
+            }
+
+            for (Object key : response.responseData.keySet()) {
+                collectNodes(response.get((String) key), collection);
+            }
         } else if (o instanceof List) {
             for (Object element : (List) o) {
                 collectNodes(element, collection);

--- a/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -100,7 +100,27 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
     }
 
     public List<Node> getNodes() {
-        return new ArrayList<>();
+        ArrayList<Node> children = new ArrayList<>();
+
+        if (this instanceof Node) {
+            children.add((Node) this);
+        }
+
+        for (String key : responseData.keySet()) {
+            collectNodes(get(key), children);
+        }
+
+        return children;
+    }
+
+    private void collectNodes(Object o, List<Node> collection) {
+        if (o instanceof AbstractResponse) {
+            collection.addAll(((AbstractResponse) o).getNodes());
+        } else if (o instanceof List) {
+            for (Object element : (List) o) {
+                collectNodes(element, collection);
+            }
+        }
     }
 
     public abstract boolean unwrapsToObject(String key);


### PR DESCRIPTION
Instead of generating it based on the schema, do it all at runtime with
instanceof checks. This has a few handy side-effects:
- it picks up nodes that were hidden inside unions and interfaces of
  other types
- it picks up aliased fields
- greatly reduces the size of the generated code

The cost is that we will iterate over *all* keys and values at run-time even if we know from the schema that they are just scalars.

@dylanahsmith @DanielJette supersedes #14.