### PR TITLE
fix: Incomplete generated code when query/mutation not in schema

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,8 @@ task :generate do
   require 'graphql_java_gen'
   require_relative 'codegen/test/support/schema'
 
-  schema = GraphQLSchema.new(Support::Schema.introspection_result)
-  generator = GraphQLJavaGen.new(schema,
+  GraphQLJavaGen.new(
+    GraphQLSchema.new(Support::Schema.introspection_result),
     package_name: 'com.shopify.graphql.support',
     nest_under: 'Generated',
     custom_scalars: [
@@ -26,8 +26,13 @@ task :generate do
         imports: ['java.time.LocalDateTime'],
       )
     ]
-  )
-  generator.save('support/src/test/java/com/shopify/graphql/support/Generated.java')
+  ).save('support/src/test/java/com/shopify/graphql/support/Generated.java')
+
+  GraphQLJavaGen.new(
+    GraphQLSchema.new(Support::Schema.introspection_result(Support::Schema::MinimalSchema)),
+    package_name: 'com.shopify.graphql.support',
+    nest_under: 'GeneratedMinimal',
+  ).save('support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java')
 end
 
 task :default => :test

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class <%= schema_name %> {
     <% [[:query, schema.query_root_name], [:mutation, schema.mutation_root_name]].each do |operation_type, root_name| %>
-        <% next unless schema.mutation_root_name %>
+        <% next unless root_name %>
         public static <%= root_name %>Query <%= operation_type %>(<%= root_name %>QueryDefinition queryDef) {
             StringBuilder queryString = new StringBuilder("<%= operation_type unless operation_type == :query %>{");
             <%= root_name %>Query query = new <%= root_name %>Query(queryString);

--- a/codegen/test/graphql_java_gen_test.rb
+++ b/codegen/test/graphql_java_gen_test.rb
@@ -6,12 +6,12 @@ class GraphQLJavaGenTest < Minitest::Test
   end
 
   def test_default_script_name
-    output = GraphQLJavaGen.new(SIMPLE_SCHEMA, **required_args).generate
+    output = GraphQLJavaGen.new(MINIMAL_SCHEMA, **required_args).generate
     assert_match %r{\A// Generated from graphql_java_gen gem$}, output
   end
 
   def test_script_name_option
-    output = GraphQLJavaGen.new(SIMPLE_SCHEMA, script_name: 'script/update_schema', **required_args).generate
+    output = GraphQLJavaGen.new(MINIMAL_SCHEMA, script_name: 'script/update_schema', **required_args).generate
     assert_match %r{\A// Generated from script/update_schema$}, output
   end
 

--- a/codegen/test/support/schema.rb
+++ b/codegen/test/support/schema.rb
@@ -111,9 +111,14 @@ module Support
       resolve_type ->(obj, ctx) {}
     end
 
-    NoMutationSchema = GraphQL::Schema.define do
-      query QueryType
-      orphan_types [StringEntryType, IntegerEntryType]
+    MinimalQueryType = GraphQL::ObjectType.define do
+      name "QueryRoot"
+
+      field :version, types.String
+    end
+
+    MinimalSchema = GraphQL::Schema.define do
+      query MinimalQueryType
       resolve_type ->(obj, ctx) {}
     end
 

--- a/codegen/test/test_helper.rb
+++ b/codegen/test/test_helper.rb
@@ -7,5 +7,5 @@ require 'minitest/autorun'
 
 require 'support/schema'
 
-SIMPLE_SCHEMA = GraphQLSchema.new(Support::Schema.introspection_result(Support::Schema::NoMutationSchema))
+MINIMAL_SCHEMA = GraphQLSchema.new(Support::Schema.introspection_result(Support::Schema::MinimalSchema))
 LARGER_SCHEMA = GraphQLSchema.new(Support::Schema.introspection_result)

--- a/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
+++ b/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
@@ -1,0 +1,136 @@
+// Generated from graphql_java_gen gem
+
+package com.shopify.graphql.support;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.shopify.graphql.support.AbstractResponse;
+import com.shopify.graphql.support.Arguments;
+import com.shopify.graphql.support.Error;
+import com.shopify.graphql.support.Query;
+import com.shopify.graphql.support.SchemaViolationError;
+import com.shopify.graphql.support.TopLevelResponse;
+
+import com.shopify.graphql.support.ID;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class GeneratedMinimal {
+    public static QueryRootQuery query(QueryRootQueryDefinition queryDef) {
+        StringBuilder queryString = new StringBuilder("{");
+        QueryRootQuery query = new QueryRootQuery(queryString);
+        queryDef.define(query);
+        queryString.append('}');
+        return query;
+    }
+
+    public static class QueryResponse {
+        private TopLevelResponse response;
+        private QueryRoot data;
+
+        public QueryResponse(TopLevelResponse response) throws SchemaViolationError {
+            this.response = response;
+            this.data = response.getData() != null ? new QueryRoot(response.getData()) : null;
+        }
+
+        public QueryRoot getData() {
+            return data;
+        }
+
+        public List<Error> getErrors() {
+            return response.getErrors();
+        }
+
+        public String toJson() {
+            return new Gson().toJson(response);
+        }
+
+        public String prettyPrintJson() {
+            final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            return gson.toJson(response);
+        }
+
+        public static QueryResponse fromJson(String json) throws SchemaViolationError {
+            final TopLevelResponse response = new Gson().fromJson(json, TopLevelResponse.class);
+            return new QueryResponse(response);
+        }
+    }
+
+    public interface QueryRootQueryDefinition {
+        void define(QueryRootQuery _queryBuilder);
+    }
+
+    public static class QueryRootQuery extends Query<QueryRootQuery> {
+        QueryRootQuery(StringBuilder _queryBuilder) {
+            super(_queryBuilder);
+        }
+
+        public QueryRootQuery version() {
+            startField("version");
+
+            return this;
+        }
+
+        public String toString() {
+            return _queryBuilder.toString();
+        }
+    }
+
+    public static class QueryRoot extends AbstractResponse<QueryRoot> {
+        public QueryRoot() {
+        }
+
+        public QueryRoot(JsonObject fields) throws SchemaViolationError {
+            for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+                String key = field.getKey();
+                String fieldName = getFieldName(key);
+                switch (fieldName) {
+                    case "version": {
+                        String optional1 = null;
+                        if (!field.getValue().isJsonNull()) {
+                            optional1 = jsonAsString(field.getValue(), key);
+                        }
+
+                        responseData.put(key, optional1);
+
+                        break;
+                    }
+
+                    case "__typename": {
+                        responseData.put(key, jsonAsString(field.getValue(), key));
+                        break;
+                    }
+                    default: {
+                        throw new SchemaViolationError(this, key, field.getValue());
+                    }
+                }
+            }
+        }
+
+        public String getGraphQlTypeName() {
+            return "QueryRoot";
+        }
+
+        public String getVersion() {
+            return (String) get("version");
+        }
+
+        public QueryRoot setVersion(String arg) {
+            optimisticData.put("version", arg);
+            return this;
+        }
+
+        public boolean unwrapsToObject(String key) {
+            switch (getFieldName(key)) {
+                case "version": return false;
+
+                default: return false;
+            }
+        }
+    }
+}

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 public class IntegrationTest {
     @Test
     public void testStringFieldQuery() throws Exception {
-        String queryString = Generated.query(query -> query.version()).toString();
+        String queryString = GeneratedMinimal.query(query -> query.version()).toString();
         assertEquals("{version}", queryString);
     }
 
@@ -73,7 +73,7 @@ public class IntegrationTest {
     @Test
     public void testStringFieldResponse() throws Exception {
         String json = "{\"data\":{\"version\":\"1.2.3\"}}";
-        Generated.QueryRoot data = Generated.QueryResponse.fromJson(json).getData();
+        GeneratedMinimal.QueryRoot data = GeneratedMinimal.QueryResponse.fromJson(json).getData();
         assertEquals("1.2.3", data.getVersion());
     }
 


### PR DESCRIPTION
The current code does not properly generate code when only queries are defined in the grapnel schema. (And I believe there should also be issues when only mutations exist too)

Line 26 in codegen/lib/graphql_java_gen/templates/APISchema.java.erb was the issue.

I believe this PR fixes the problem. (Kid gloves please, I don't actually know ruby)
Added integration test for query only schema as well.