### PR TITLE
Fix support for unions by treating them as interfaces with no fields

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -67,6 +67,7 @@ public class <%= schema_name %> {
 
     <% schema.types.reject{ |type| type.name.start_with?('__') || type.scalar? }.each do |type| %>
         <% case type.kind when 'OBJECT', 'INTERFACE', 'UNION' %>
+            <% fields = type.fields || [] %>
             public interface <%= type.name %>QueryDefinition {
                 void define(<%= type.name %>Query _queryBuilder);
             }
@@ -82,7 +83,7 @@ public class <%= schema_name %> {
                     <% end %>
                 }
 
-                <% type.fields.each do |field| %>
+                <% fields.each do |field| %>
                     <% next if field.name == "id" && type.object? && type.implement?("Node") %>
                     <% unless field.optional_args.empty? %>
                         public class <%= field.classify_name %>Arguments extends Arguments {
@@ -161,7 +162,7 @@ public class <%= schema_name %> {
                   public interface <%= type.name %> {
                 <% end %>
                     String getGraphQlTypeName();
-                    <% type.fields.each do |field| %>
+                    <% fields.each do |field| %>
                         <%= java_output_type(field.type) %> get<%= field.classify_name %>();
                     <% end %>
                 }
@@ -177,7 +178,7 @@ public class <%= schema_name %> {
                     String key = field.getKey();
                     String fieldName = getFieldName(key);
                     switch (fieldName) {
-                      <% type.fields.each do |field| %>
+                      <% fields.each do |field| %>
                         case "<%= field.name %>": {
                           <% generate_build_output_code("field.getValue()", field.type) do |statements, expr| %>
                             <%= statements %>
@@ -228,7 +229,7 @@ public class <%= schema_name %> {
                     }
                 <% end %>
 
-                <% type.fields.each do |field| %>
+                <% fields.each do |field| %>
                     <%= java_annotations(field) %>
                     public <%= java_output_type(field.type) %> get<%= field.classify_name %>() {
                       return (<%= java_output_type(field.type) %>) get("<%= field.name %>");
@@ -243,7 +244,7 @@ public class <%= schema_name %> {
 
                   public boolean unwrapsToObject(String key) {
                     switch (getFieldName(key)) {
-                      <% type.fields.each do |field| %>
+                      <% fields.each do |field| %>
                         case "<%= field.name %>": return <%= field.type.unwrap.object? %>;
                       <% end %>
                       default: return false;

--- a/codegen/test/support/schema.rb
+++ b/codegen/test/support/schema.rb
@@ -38,6 +38,11 @@ module Support
       field :ttl, TimeType
     end
 
+    EntryUnionType = GraphQL::UnionType.define do
+      name "EntryUnion"
+      possible_types [StringEntryType, IntegerEntryType]
+    end
+
     QueryType = GraphQL::ObjectType.define do
       name "QueryRoot"
 
@@ -57,6 +62,10 @@ module Support
       end
       field :entry, EntryType do
         description "Get an entry of any type with the given key"
+        argument :key, !types.String
+      end
+      field :entry_union, EntryUnionType do
+        description "Get an entry of any type with the given key as a union"
         argument :key, !types.String
       end
       field :type, KeyType do

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -236,6 +236,84 @@ public class Generated {
         }
     }
 
+    public interface EntryUnionQueryDefinition {
+        void define(EntryUnionQuery _queryBuilder);
+    }
+
+    public static class EntryUnionQuery extends Query<EntryUnionQuery> {
+        EntryUnionQuery(StringBuilder _queryBuilder) {
+            super(_queryBuilder);
+
+            startField("__typename");
+        }
+
+        public EntryUnionQuery onIntegerEntry(IntegerEntryQueryDefinition queryDef) {
+            startInlineFragment("IntegerEntry");
+            queryDef.define(new IntegerEntryQuery(_queryBuilder));
+            _queryBuilder.append('}');
+            return this;
+        }
+
+        public EntryUnionQuery onStringEntry(StringEntryQueryDefinition queryDef) {
+            startInlineFragment("StringEntry");
+            queryDef.define(new StringEntryQuery(_queryBuilder));
+            _queryBuilder.append('}');
+            return this;
+        }
+    }
+
+    public interface EntryUnion {
+        String getGraphQlTypeName();
+    }
+
+    public static class UnknownEntryUnion extends AbstractResponse<UnknownEntryUnion> implements EntryUnion {
+        public UnknownEntryUnion() {
+        }
+
+        public UnknownEntryUnion(JsonObject fields) throws SchemaViolationError {
+            for (Map.Entry<String, JsonElement> field : fields.entrySet()) {
+                String key = field.getKey();
+                String fieldName = getFieldName(key);
+                switch (fieldName) {
+                    case "__typename": {
+                        responseData.put(key, jsonAsString(field.getValue(), key));
+                        break;
+                    }
+                    default: {
+                        throw new SchemaViolationError(this, key, field.getValue());
+                    }
+                }
+            }
+        }
+
+        public static EntryUnion create(JsonObject fields) throws SchemaViolationError {
+            String typeName = fields.getAsJsonPrimitive("__typename").getAsString();
+            switch (typeName) {
+                case "IntegerEntry": {
+                    return new IntegerEntry(fields);
+                }
+
+                case "StringEntry": {
+                    return new StringEntry(fields);
+                }
+
+                default: {
+                    return new UnknownEntryUnion(fields);
+                }
+            }
+        }
+
+        public String getGraphQlTypeName() {
+            return (String) get("__typename");
+        }
+
+        public boolean unwrapsToObject(String key) {
+            switch (getFieldName(key)) {
+                default: return false;
+            }
+        }
+    }
+
     public interface IntegerEntryQueryDefinition {
         void define(IntegerEntryQuery _queryBuilder);
     }
@@ -264,7 +342,7 @@ public class Generated {
         }
     }
 
-    public static class IntegerEntry extends AbstractResponse<IntegerEntry> implements Entry {
+    public static class IntegerEntry extends AbstractResponse<IntegerEntry> implements Entry, EntryUnion {
         public IntegerEntry() {
         }
 
@@ -613,6 +691,21 @@ public class Generated {
             return this;
         }
 
+        public QueryRootQuery entryUnion(String key, EntryUnionQueryDefinition queryDef) {
+            startField("entry_union");
+
+            _queryBuilder.append("(key:");
+            Query.appendQuotedString(_queryBuilder, key.toString());
+
+            _queryBuilder.append(')');
+
+            _queryBuilder.append('{');
+            queryDef.define(new EntryUnionQuery(_queryBuilder));
+            _queryBuilder.append('}');
+
+            return this;
+        }
+
         public QueryRootQuery integer(String key) {
             startField("integer");
 
@@ -742,6 +835,17 @@ public class Generated {
                         break;
                     }
 
+                    case "entry_union": {
+                        EntryUnion optional1 = null;
+                        if (!field.getValue().isJsonNull()) {
+                            optional1 = UnknownEntryUnion.create(jsonAsObject(field.getValue(), key));
+                        }
+
+                        responseData.put(key, optional1);
+
+                        break;
+                    }
+
                     case "integer": {
                         Integer optional1 = null;
                         if (!field.getValue().isJsonNull()) {
@@ -841,6 +945,15 @@ public class Generated {
             return this;
         }
 
+        public EntryUnion getEntryUnion() {
+            return (EntryUnion) get("entry_union");
+        }
+
+        public QueryRoot setEntryUnion(EntryUnion arg) {
+            optimisticData.put(getKey("entry_union"), arg);
+            return this;
+        }
+
         public Integer getInteger() {
             return (Integer) get("integer");
         }
@@ -900,6 +1013,8 @@ public class Generated {
                 case "entries": return false;
 
                 case "entry": return false;
+
+                case "entry_union": return false;
 
                 case "integer": return false;
 
@@ -1029,7 +1144,7 @@ public class Generated {
         }
     }
 
-    public static class StringEntry extends AbstractResponse<StringEntry> implements Entry {
+    public static class StringEntry extends AbstractResponse<StringEntry> implements Entry, EntryUnion {
         public StringEntry() {
         }
 

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -40,6 +40,16 @@ public class IntegrationTest {
     }
 
     @Test
+    public void testUnionQuery() throws Exception {
+        String queryString = Generated.query(query ->
+            query.entryUnion("user:1", entry -> entry
+                .onStringEntry(strEntry -> strEntry.value())
+            )
+        ).toString();
+        assertEquals("{entry_union(key:\"user:1\"){__typename,... on StringEntry{value}}}", queryString);
+    }
+
+    @Test
     public void testEnumInput() throws Exception {
         String queryString = Generated.query(query -> query
             .keys(10, args -> args.type(Generated.KeyType.INTEGER))
@@ -121,6 +131,23 @@ public class IntegrationTest {
         assertEquals("FutureEntry", entry.getGraphQlTypeName());
         assertTrue(entry instanceof Generated.UnknownEntry);
         assertEquals("foo", entry.getKey());
+    }
+
+    @Test
+    public void testUnionResponse() throws Exception {
+        String json = "{\"data\":{\"entry_union\":{\"__typename\":\"IntegerEntry\",\"value\":42}}}";
+        Generated.EntryUnion entry = Generated.QueryResponse.fromJson(json).getData().getEntryUnion();
+        assertEquals("IntegerEntry", entry.getGraphQlTypeName());
+        assertTrue(entry instanceof Generated.IntegerEntry);
+        assertEquals(42, ((Generated.IntegerEntry) entry).getValue().intValue());
+    }
+
+    @Test
+    public void testUnionUnknownTypeResponse() throws Exception {
+        String json = "{\"data\":{\"entry_union\":{\"__typename\":\"FutureEntry\"}}}";
+        Generated.EntryUnion entry = Generated.QueryResponse.fromJson(json).getData().getEntryUnion();
+        assertEquals("FutureEntry", entry.getGraphQlTypeName());
+        assertTrue(entry instanceof Generated.UnknownEntryUnion);
     }
 
     @Test


### PR DESCRIPTION
Fixes #9

## Problem

The schema we use for mobile-shopify never had any unions in it so we never tested that the generator works for them.

My intention was for unions to work like interfaces with no fields.  However, introspection result returns `null` for the `fields` field on a union type rather than an empty array, which wasn't handled in the generator.

The other problem with our union support was that we were using the `interfaces` field on object types, which doesn't include unions, so also prevented unions from being handled similar to interfaces.

## Solution

Handle the `null` fields for a union type by using a `fields = type.fields || []` variable instead of `type.fields` directly.

To get the java interfaces for an object type, I had to go through all the types to find unions or interfaces that listed the object type as a possible type.  This mapping is memoized to only do a single iteration over the schema types for this purpose.