### PR TITLE
Resolve conflict with getNodes name

### DIFF
--- a/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
+++ b/support/src/main/java/com/shopify/graphql/support/AbstractResponse.java
@@ -103,7 +103,7 @@ public abstract class AbstractResponse<T extends AbstractResponse> implements Se
         return element.getAsJsonArray();
     }
 
-    public List<Node> getNodes() {
+    public List<Node> collectNodes() {
         final ArrayList<Node> children = new ArrayList<>();
 
         collectNodes(this, children);


### PR DESCRIPTION
StoreFront schema defines resource `Nodes` that causes compilation error as getter method for this resource conflicts with `AbstractResponse#getNodes`.