### PR TITLE
Add optional flag to include deprecated fields

### DIFF
--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -38,7 +38,7 @@ class GraphQLJavaGen
     private
 
     def erb_for(template_filename)
-      erb = ERB.new(File.read(template_filename), 0, '-')
+      erb = ERB.new(File.read(template_filename), nil, '-')
       erb.filename = template_filename
       erb
     end
@@ -286,7 +286,7 @@ class GraphQLJavaGen
     end
 
     if element.respond_to?(:deprecated?) && element.deprecated?
-      if (doc.length > 0)
+      unless doc.empty?
         doc << "\n*"
         doc << "\n*"
       else
@@ -296,11 +296,7 @@ class GraphQLJavaGen
       doc << element.deprecation_reason
     end
 
-    if (doc.length > 0)
-      doc = "/**\n" + doc + "\n*/"
-    end
-
-    doc
+    doc.empty? ? doc : "/**\n" + doc + "\n*/"
   end
 
   def wrap_text(text, col_width=80)

--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -7,11 +7,11 @@ require 'erb'
 require 'set'
 
 class GraphQLJavaGen
-  attr_reader :schema, :package_name, :scalars, :imports, :script_name, :schema_name
+  attr_reader :schema, :package_name, :scalars, :imports, :script_name, :schema_name, :include_deprecated
 
   def initialize(schema,
     package_name:, nest_under:, script_name: 'graphql_java_gen gem',
-    custom_scalars: [], custom_annotations: []
+    custom_scalars: [], custom_annotations: [], include_deprecated: false
   )
     @schema = schema
     @schema_name = nest_under
@@ -21,6 +21,7 @@ class GraphQLJavaGen
     @scalars.default_proc = ->(hash, key) { DEFAULT_SCALAR }
     @annotations = custom_annotations
     @imports = (@scalars.values.map(&:imports) + @annotations.map(&:imports)).flatten.sort.uniq
+    @include_deprecated = include_deprecated
   end
 
   def save(path)
@@ -37,7 +38,7 @@ class GraphQLJavaGen
     private
 
     def erb_for(template_filename)
-      erb = ERB.new(File.read(template_filename))
+      erb = ERB.new(File.read(template_filename), 0, '-')
       erb.filename = template_filename
       erb
     end
@@ -280,11 +281,25 @@ class GraphQLJavaGen
     unless element.description.nil?
       description = wrap_text(element.description, 100)
       description = description.chomp("\n").gsub("\n", "\n* ")
-      doc << "/**\n"
       doc << '* '
       doc << description
-      doc << "\n*/"
     end
+
+    if element.respond_to?(:deprecated?) && element.deprecated?
+      if (doc.length > 0)
+        doc << "\n*"
+        doc << "\n*"
+      else
+        doc << '*'        
+      end
+      doc << ' @deprecated '
+      doc << element.deprecation_reason
+    end
+
+    if (doc.length > 0)
+      doc = "/**\n" + doc + "\n*/"
+    end
+
     doc
   end
 

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -67,7 +67,7 @@ public class <%= schema_name %> {
 
     <% schema.types.reject{ |type| type.name.start_with?('__') || type.scalar? }.each do |type| %>
         <% case type.kind when 'OBJECT', 'INTERFACE', 'UNION' %>
-            <% fields = type.fields || [] %>
+            <% fields = type.fields(include_deprecated: include_deprecated) || [] %>
             public interface <%= type.name %>QueryDefinition {
                 void define(<%= type.name %>Query _queryBuilder);
             }
@@ -115,7 +115,7 @@ public class <%= schema_name %> {
                     <% end %>
 
                     <%= java_doc(field) %>
-                    public <%= type.name %>Query <%= escape_reserved_word(field.camelize_name) %>(<%= java_arg_defs(field) %>) {
+                    <%= field.deprecated? ? '@Deprecated' : '' %> public <%= type.name %>Query <%= escape_reserved_word(field.camelize_name) %>(<%= java_arg_defs(field) %>) {
                         startField("<%= field.name %>");
                         <% unless field.args.empty? %>
                             <% if field.required_args.empty? %>
@@ -236,7 +236,7 @@ public class <%= schema_name %> {
 
                 <% fields.each do |field| %>
                     <%= java_doc(field) %>
-                    <%= java_annotations(field) %>
+                    <%= java_annotations(field) -%>
                     public <%= java_output_type(field.type) %> get<%= field.classify_name %>() {
                       return (<%= java_output_type(field.type) %>) get("<%= field.name %>");
                     }

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -115,7 +115,8 @@ public class <%= schema_name %> {
                     <% end %>
 
                     <%= java_doc(field) %>
-                    <%= field.deprecated? ? '@Deprecated' : '' %> public <%= type.name %>Query <%= escape_reserved_word(field.camelize_name) %>(<%= java_arg_defs(field) %>) {
+                    <%= field.deprecated? ? "@Deprecated\n" : '' -%>
+                    public <%= type.name %>Query <%= escape_reserved_word(field.camelize_name) %>(<%= java_arg_defs(field) %>) {
                         startField("<%= field.name %>");
                         <% unless field.args.empty? %>
                             <% if field.required_args.empty? %>
@@ -318,9 +319,12 @@ public class <%= schema_name %> {
         <% when 'ENUM' %>
             <%= java_doc(type) %>
             public enum <%= type.name %> {
-              <% type.enum_values.each do |value| %>
+              <% type.enum_values(include_deprecated: include_deprecated).each do |value| %>
+                <%= java_doc(value) %>
+                <%= value.deprecated? ? "@Deprecated\n" : '' -%>
                 <%= value.upcase_name %>,
               <% end %>
+
               UNKNOWN_VALUE;
 
               public static <%= type.name %> fromGraphQl(String value) {


### PR DESCRIPTION
MobileBuy SDK requires to include deprecated fields that by default excluded from generation.

This PR:
- adds optional `include_deprecated` flag by default it's set to false
- generate java `Deprecated` annotation for deprecated fields
- if `include_deprecated` is set to `true` includes deprecated fields into generation

Example of generated deprecated fields:
```java
/**
* The three-letter code for the currency that the shop accepts.
*
* @deprecated Use `paymentSettings` instead
*/
@Deprecated public ShopQuery currencyCode() {
    startField("currencyCode");

    return this;
}
```

Closes https://github.com/Shopify/graphql_java_gen/issues/6