### PR TITLE
Allow setting optional fields on input objects to explicit null

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,12 @@ task :generate do
         deserialize_expr: ->(expr) { "LocalDateTime.parse(jsonAsString(#{expr}, key))" },
         imports: ['java.time.LocalDateTime'],
       )
+    ],
+    custom_annotations: [
+      GraphQLJavaGen::Annotation.new(
+        'Nullable',
+        imports: ['com.shopify.graphql.support.Nullable']
+      ) { |field| !field.type.non_null? },
     ]
   ).save('support/src/test/java/com/shopify/graphql/support/Generated.java')
 

--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -257,6 +257,8 @@ class GraphQLJavaGen
     annotations = @annotations.map do |annotation|
       "@#{annotation.name}" if annotation.annotate?(field)
     end.compact
+    return "" unless annotations.any?
+
     if in_argument
       annotations.join(" ") + " "
     else

--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -253,10 +253,15 @@ class GraphQLJavaGen
     "implements #{interfaces.to_a.join(', ')} "
   end
 
-  def java_annotations(field)
-    @annotations.map do |annotation|
+  def java_annotations(field, in_argument: false)
+    annotations = @annotations.map do |annotation|
       "@#{annotation.name}" if annotation.annotate?(field)
-    end.compact.join("\n")
+    end.compact
+    if in_argument
+      annotations.join(" ") + " "
+    else
+      annotations.join("\n")
+    end
   end
 
   def type_names_set

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -265,7 +265,7 @@ public class <%= schema_name %> {
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
                   private <%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>;
-                  private boolean <%= escape_reserved_word(field.name) %>Seen = false;
+                  private boolean <%= field.camelize_name %>Seen = false;
                 <% end %>
 
                 <% unless type.required_input_fields.empty? %>

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -18,6 +18,7 @@ import com.shopify.graphql.support.TopLevelResponse;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -266,6 +267,7 @@ public class <%= schema_name %> {
                 <% type.optional_input_fields.each do |field| %>
                   private <%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>;
                 <% end %>
+                  private HashSet<String> fieldsSeen = new HashSet<>();
 
                 <% unless type.required_input_fields.empty? %>
                   public <%= type.name %>(<%= type.required_input_fields.map{ |field| "#{java_input_type(field.type)} #{escape_reserved_word(field.camelize_name)}" }.join(', ') %>) {
@@ -292,6 +294,7 @@ public class <%= schema_name %> {
 
                   public <%= type.name %> set<%= field.classify_name %>(<%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
+                      fieldsSeen.add("<%= field.name %>");
                       return this;
                   }
                 <% end %>
@@ -306,11 +309,15 @@ public class <%= schema_name %> {
                     <%= generate_build_input_code(escape_reserved_word(field.camelize_name), field.type) %>
                   <% end %>
                   <% type.optional_input_fields.each do |field| %>
-                    if (<%= escape_reserved_word(field.camelize_name) %> != null) {
+                    if (fieldsSeen.contains("<%= field.name %>")) {
                       _queryBuilder.append(separator);
                       separator = ",";
                       _queryBuilder.append("<%= field.name %>:");
-                      <%= generate_build_input_code(escape_reserved_word(field.camelize_name), field.type) %>
+                      if (<%= escape_reserved_word(field.camelize_name) %> != null) {
+                        <%= generate_build_input_code(escape_reserved_word(field.camelize_name), field.type) %>
+                      } else {
+                        _queryBuilder.append("null");
+                      }
                     }
                   <% end %>
                   _queryBuilder.append('}');

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -237,7 +237,7 @@ public class <%= schema_name %> {
 
                 <% fields.each do |field| %>
                     <%= java_doc(field) %>
-                    <%= java_annotations(field) -%>
+                    <%= java_annotations(field) %>
                     public <%= java_output_type(field.type) %> get<%= field.classify_name %>() {
                       return (<%= java_output_type(field.type) %>) get("<%= field.name %>");
                     }
@@ -277,23 +277,23 @@ public class <%= schema_name %> {
                 <% end %>
 
                 <% type.required_input_fields.each do |field| %>
-                  <%= java_annotations(field) -%>
+                  <%= java_annotations(field) %>
                   public <%= java_input_type(field.type) %> get<%= field.classify_name %>() {
                       return <%= escape_reserved_word(field.camelize_name) %>;
                   }
 
-                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field).gsub(/(.)$/, '\1 ') %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
+                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field, in_argument: true) %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
                       return this;
                   }
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
-                  <%= java_annotations(field) -%>
+                  <%= java_annotations(field) %>
                   public <%= java_input_type(field.type) %> get<%= field.classify_name %>() {
                       return <%= escape_reserved_word(field.camelize_name) %>;
                   }
 
-                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field).gsub(/(.)$/, '\1 ') %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
+                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field, in_argument: true) %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
                       this.<%= escape_reserved_word(field.name) %>Seen = true;
                       return this;

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -277,21 +277,23 @@ public class <%= schema_name %> {
                 <% end %>
 
                 <% type.required_input_fields.each do |field| %>
+                  <%= java_annotations(field) -%>
                   public <%= java_input_type(field.type) %> get<%= field.classify_name %>() {
                       return <%= escape_reserved_word(field.camelize_name) %>;
                   }
 
-                  public <%= type.name %> set<%= field.classify_name %>(<%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
+                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field).gsub(/(.)$/, '\1 ') %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
                       return this;
                   }
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
+                  <%= java_annotations(field) -%>
                   public <%= java_input_type(field.type) %> get<%= field.classify_name %>() {
                       return <%= escape_reserved_word(field.camelize_name) %>;
                   }
 
-                  public <%= type.name %> set<%= field.classify_name %>(<%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
+                  public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field).gsub(/(.)$/, '\1 ') %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
                       this.<%= escape_reserved_word(field.name) %>Seen = true;
                       return this;

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -295,7 +295,7 @@ public class <%= schema_name %> {
 
                   public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field, in_argument: true) %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
-                      this.<%= escape_reserved_word(field.name) %>Seen = true;
+                      this.<%= field.camelize_name %>Seen = true;
                       return this;
                   }
                 <% end %>
@@ -310,7 +310,7 @@ public class <%= schema_name %> {
                     <%= generate_build_input_code(escape_reserved_word(field.camelize_name), field.type) %>
                   <% end %>
                   <% type.optional_input_fields.each do |field| %>
-                    if (this.<%= escape_reserved_word(field.name) %>Seen) {
+                    if (this.<%= field.camelize_name %>Seen) {
                       _queryBuilder.append(separator);
                       separator = ",";
                       _queryBuilder.append("<%= field.name %>:");

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -18,7 +18,6 @@ import com.shopify.graphql.support.TopLevelResponse;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -266,8 +265,8 @@ public class <%= schema_name %> {
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
                   private <%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>;
+                  private boolean <%= escape_reserved_word(field.name) %>Seen = false;
                 <% end %>
-                  private HashSet<String> fieldsSeen = new HashSet<>();
 
                 <% unless type.required_input_fields.empty? %>
                   public <%= type.name %>(<%= type.required_input_fields.map{ |field| "#{java_input_type(field.type)} #{escape_reserved_word(field.camelize_name)}" }.join(', ') %>) {
@@ -294,7 +293,7 @@ public class <%= schema_name %> {
 
                   public <%= type.name %> set<%= field.classify_name %>(<%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
-                      fieldsSeen.add("<%= field.name %>");
+                      this.<%= escape_reserved_word(field.name) %>Seen = true;
                       return this;
                   }
                 <% end %>
@@ -309,7 +308,7 @@ public class <%= schema_name %> {
                     <%= generate_build_input_code(escape_reserved_word(field.camelize_name), field.type) %>
                   <% end %>
                   <% type.optional_input_fields.each do |field| %>
-                    if (fieldsSeen.contains("<%= field.name %>")) {
+                    if (this.<%= escape_reserved_word(field.name) %>Seen) {
                       _queryBuilder.append(separator);
                       separator = ",";
                       _queryBuilder.append("<%= field.name %>:");

--- a/codegen/test/support/schema.rb
+++ b/codegen/test/support/schema.rb
@@ -91,6 +91,7 @@ module Support
       argument :value, !types.Int
       argument :ttl, TimeType
       argument :negate, types.Boolean, default_value: false
+      argument :api_client, types.String
     end
 
     MutationType = GraphQL::ObjectType.define do

--- a/support/src/main/java/com/shopify/graphql/support/Nullable.java
+++ b/support/src/main/java/com/shopify/graphql/support/Nullable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.shopify.graphql.support;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a parameter, field or method return value can be null.
+ * <p>
+ * When decorating a method call parameter, this denotes that the parameter can
+ * legitimately be null and the method will gracefully deal with it. Typically
+ * used on optional parameters.
+ * <p>
+ * When decorating a method, this denotes the method might legitimately return
+ * null.
+ * <p>
+ * This is a marker annotation and it has no specific attributes.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD, PARAMETER, FIELD, ANNOTATION_TYPE, PACKAGE})
+public @interface Nullable {
+}
+

--- a/support/src/test/java/com/shopify/graphql/support/AnnotationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/AnnotationTest.java
@@ -1,0 +1,28 @@
+package com.shopify.graphql.support;
+
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.shopify.graphql.support.Generated;
+
+public class AnnotationTest {
+    @Test
+    public void testAppliesAnnotation() throws Exception {
+      Class<Generated> obj = Generated.class;
+      boolean foundNullable = false;
+      for (Class klass: obj.getDeclaredClasses()) {
+        for (Method method : klass.getDeclaredMethods()) {
+          if (method.isAnnotationPresent(Nullable.class)) {
+            foundNullable = true;
+            break;
+          }
+        }
+      }
+      assertTrue("Should have found a class with @Nullable annotation in Generated.java", foundNullable);
+    }
+}

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1082,6 +1082,9 @@ public class Generated {
         private Boolean negate;
         private boolean negateSeen = false;
 
+        private String apiClient;
+        private boolean apiClientSeen = false;
+
         public SetIntegerInput(String key, int value) {
             this.key = key;
 
@@ -1128,6 +1131,17 @@ public class Generated {
             return this;
         }
 
+        @Nullable
+        public String getApiClient() {
+            return apiClient;
+        }
+
+        public SetIntegerInput setApiClient(@Nullable String apiClient) {
+            this.apiClient = apiClient;
+            this.apiClientSeen = true;
+            return this;
+        }
+
         public void appendTo(StringBuilder _queryBuilder) {
             String separator = "";
             _queryBuilder.append('{');
@@ -1159,6 +1173,17 @@ public class Generated {
                 _queryBuilder.append("negate:");
                 if (negate != null) {
                     _queryBuilder.append(negate);
+                } else {
+                    _queryBuilder.append("null");
+                }
+            }
+
+            if (this.apiClientSeen) {
+                _queryBuilder.append(separator);
+                separator = ",";
+                _queryBuilder.append("api_client:");
+                if (apiClient != null) {
+                    Query.appendQuotedString(_queryBuilder, apiClient.toString());
                 } else {
                     _queryBuilder.append("null");
                 }

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -1067,10 +1066,10 @@ public class Generated {
         private int value;
 
         private LocalDateTime ttl;
+        private boolean ttlSeen = false;
 
         private Boolean negate;
-
-        private HashSet<String> fieldsSeen = new HashSet<>();
+        private boolean negateSeen = false;
 
         public SetIntegerInput(String key, int value) {
             this.key = key;
@@ -1102,7 +1101,7 @@ public class Generated {
 
         public SetIntegerInput setTtl(LocalDateTime ttl) {
             this.ttl = ttl;
-            fieldsSeen.add("ttl");
+            this.ttlSeen = true;
             return this;
         }
 
@@ -1112,7 +1111,7 @@ public class Generated {
 
         public SetIntegerInput setNegate(Boolean negate) {
             this.negate = negate;
-            fieldsSeen.add("negate");
+            this.negateSeen = true;
             return this;
         }
 
@@ -1130,7 +1129,7 @@ public class Generated {
             _queryBuilder.append("value:");
             _queryBuilder.append(value);
 
-            if (fieldsSeen.contains("ttl")) {
+            if (this.ttlSeen) {
                 _queryBuilder.append(separator);
                 separator = ",";
                 _queryBuilder.append("ttl:");
@@ -1141,7 +1140,7 @@ public class Generated {
                 }
             }
 
-            if (fieldsSeen.contains("negate")) {
+            if (this.negateSeen) {
                 _queryBuilder.append(separator);
                 separator = ",";
                 _queryBuilder.append("negate:");

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -429,6 +430,9 @@ public class Generated {
         }
     }
 
+    /**
+    * Types of values that can be stored in a key
+    */
     public enum KeyType {
         INTEGER,
 
@@ -676,6 +680,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get an entry of any type with the given key
+        */
         public QueryRootQuery entry(String key, EntryQueryDefinition queryDef) {
             startField("entry");
 
@@ -691,6 +698,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get an entry of any type with the given key as a union
+        */
         public QueryRootQuery entryUnion(String key, EntryUnionQueryDefinition queryDef) {
             startField("entry_union");
 
@@ -706,6 +716,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get a integer value with the given key
+        */
         public QueryRootQuery integer(String key) {
             startField("integer");
 
@@ -760,6 +773,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get a string value with the given key
+        */
         public QueryRootQuery string(String key) {
             startField("string");
 
@@ -936,6 +952,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get an entry of any type with the given key
+        */
         public Entry getEntry() {
             return (Entry) get("entry");
         }
@@ -945,6 +964,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get an entry of any type with the given key as a union
+        */
         public EntryUnion getEntryUnion() {
             return (EntryUnion) get("entry_union");
         }
@@ -954,6 +976,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get a integer value with the given key
+        */
         public Integer getInteger() {
             return (Integer) get("integer");
         }
@@ -972,6 +997,9 @@ public class Generated {
             return this;
         }
 
+        /**
+        * Get a string value with the given key
+        */
         public String getString() {
             return (String) get("string");
         }
@@ -1042,6 +1070,8 @@ public class Generated {
 
         private Boolean negate;
 
+        private HashSet<String> fieldsSeen = new HashSet<>();
+
         public SetIntegerInput(String key, int value) {
             this.key = key;
 
@@ -1072,6 +1102,7 @@ public class Generated {
 
         public SetIntegerInput setTtl(LocalDateTime ttl) {
             this.ttl = ttl;
+            fieldsSeen.add("ttl");
             return this;
         }
 
@@ -1081,6 +1112,7 @@ public class Generated {
 
         public SetIntegerInput setNegate(Boolean negate) {
             this.negate = negate;
+            fieldsSeen.add("negate");
             return this;
         }
 
@@ -1098,18 +1130,26 @@ public class Generated {
             _queryBuilder.append("value:");
             _queryBuilder.append(value);
 
-            if (ttl != null) {
+            if (fieldsSeen.contains("ttl")) {
                 _queryBuilder.append(separator);
                 separator = ",";
                 _queryBuilder.append("ttl:");
-                Query.appendQuotedString(_queryBuilder, ttl.toString());
+                if (ttl != null) {
+                    Query.appendQuotedString(_queryBuilder, ttl.toString());
+                } else {
+                    _queryBuilder.append("null");
+                }
             }
 
-            if (negate != null) {
+            if (fieldsSeen.contains("negate")) {
                 _queryBuilder.append(separator);
                 separator = ",";
                 _queryBuilder.append("negate:");
-                _queryBuilder.append(negate);
+                if (negate != null) {
+                    _queryBuilder.append(negate);
+                } else {
+                    _queryBuilder.append("null");
+                }
             }
 
             _queryBuilder.append('}');

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -15,6 +15,8 @@ import com.shopify.graphql.support.TopLevelResponse;
 
 import com.shopify.graphql.support.ID;
 
+import com.shopify.graphql.support.Nullable;
+
 import java.time.LocalDateTime;
 
 import java.io.Serializable;
@@ -216,6 +218,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public LocalDateTime getTtl() {
             return (LocalDateTime) get("ttl");
         }
@@ -398,6 +401,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public LocalDateTime getTtl() {
             return (LocalDateTime) get("ttl");
         }
@@ -954,6 +958,7 @@ public class Generated {
         /**
         * Get an entry of any type with the given key
         */
+        @Nullable
         public Entry getEntry() {
             return (Entry) get("entry");
         }
@@ -966,6 +971,7 @@ public class Generated {
         /**
         * Get an entry of any type with the given key as a union
         */
+        @Nullable
         public EntryUnion getEntryUnion() {
             return (EntryUnion) get("entry_union");
         }
@@ -978,6 +984,7 @@ public class Generated {
         /**
         * Get a integer value with the given key
         */
+        @Nullable
         public Integer getInteger() {
             return (Integer) get("integer");
         }
@@ -999,6 +1006,7 @@ public class Generated {
         /**
         * Get a string value with the given key
         */
+        @Nullable
         public String getString() {
             return (String) get("string");
         }
@@ -1008,6 +1016,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public LocalDateTime getTtl() {
             return (LocalDateTime) get("ttl");
         }
@@ -1017,6 +1026,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public KeyType getType() {
             return (KeyType) get("type");
         }
@@ -1026,6 +1036,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public String getVersion() {
             return (String) get("version");
         }
@@ -1081,7 +1092,7 @@ public class Generated {
             return key;
         }
 
-        public SetIntegerInput setKey(String key) {
+        public SetIntegerInput setKey( String key) {
             this.key = key;
             return this;
         }
@@ -1090,26 +1101,28 @@ public class Generated {
             return value;
         }
 
-        public SetIntegerInput setValue(int value) {
+        public SetIntegerInput setValue( int value) {
             this.value = value;
             return this;
         }
 
+        @Nullable
         public LocalDateTime getTtl() {
             return ttl;
         }
 
-        public SetIntegerInput setTtl(LocalDateTime ttl) {
+        public SetIntegerInput setTtl(@Nullable LocalDateTime ttl) {
             this.ttl = ttl;
             this.ttlSeen = true;
             return this;
         }
 
+        @Nullable
         public Boolean getNegate() {
             return negate;
         }
 
-        public SetIntegerInput setNegate(Boolean negate) {
+        public SetIntegerInput setNegate(@Nullable Boolean negate) {
             this.negate = negate;
             this.negateSeen = true;
             return this;
@@ -1239,6 +1252,7 @@ public class Generated {
             return this;
         }
 
+        @Nullable
         public LocalDateTime getTtl() {
             return (LocalDateTime) get("ttl");
         }

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1092,7 +1092,7 @@ public class Generated {
             return key;
         }
 
-        public SetIntegerInput setKey( String key) {
+        public SetIntegerInput setKey(String key) {
             this.key = key;
             return this;
         }
@@ -1101,7 +1101,7 @@ public class Generated {
             return value;
         }
 
-        public SetIntegerInput setValue( int value) {
+        public SetIntegerInput setValue(int value) {
             this.value = value;
             return this;
         }

--- a/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
+++ b/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
@@ -17,7 +17,6 @@ import com.shopify.graphql.support.ID;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 

--- a/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
+++ b/support/src/test/java/com/shopify/graphql/support/GeneratedMinimal.java
@@ -17,6 +17,7 @@ import com.shopify.graphql.support.ID;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -156,4 +156,12 @@ public class IntegrationTest {
         Generated.Mutation data = Generated.MutationResponse.fromJson(json).getData();
         assertEquals(true, data.getSetString().booleanValue());
     }
+
+    @Test
+    public void testOptionalFieldOnInput() throws Exception {
+        String queryString = Generated.mutation(mutation -> mutation
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null))
+        ).toString();
+        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:null})}", queryString);
+    }
 }


### PR DESCRIPTION
This change allows you to manually set an optional field to null on an input object.

Change is needed to so that we can delete an a child object in an update mutation. Specifically, CollectionInput needs to support setting CollectionImage to null so that it gets deleted.

Closes https://github.com/Shopify/graphql_java_gen/issues/27