### PR TITLE
Add a way to unset an input property

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -287,9 +287,11 @@ public class <%= schema_name %> {
                       return this;
                   }
 
-                  public void unSet<%= field.classify_name %>() {
+                  // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized
+                  public void unset<%= field.classify_name %>() {
                       this.<%= escape_reserved_word(field.camelize_name) %> = null;
                   }
+
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
                   <%= java_annotations(field) %>
@@ -303,10 +305,12 @@ public class <%= schema_name %> {
                       return this;
                   }
 
-                  public void unSet<%= field.classify_name %>() {
+                  // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized
+                  public void unset<%= field.classify_name %>() {
                       this.<%= escape_reserved_word(field.camelize_name) %> = null;
                       this.<%= field.camelize_name %>Seen = false;
                   }
+
                 <% end %>
 
                 public void appendTo(StringBuilder _queryBuilder) {

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -298,6 +298,11 @@ public class <%= schema_name %> {
                       this.<%= field.camelize_name %>Seen = true;
                       return this;
                   }
+
+                  public void clear<%= field.classify_name %>() {
+                      this.<%= escape_reserved_word(field.camelize_name) %> = null;
+                      this.<%= field.camelize_name %>Seen = false;
+                  }
                 <% end %>
 
                 public void appendTo(StringBuilder _queryBuilder) {

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -287,11 +287,6 @@ public class <%= schema_name %> {
                       return this;
                   }
 
-                  // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized
-                  public void unset<%= field.classify_name %>() {
-                      this.<%= escape_reserved_word(field.camelize_name) %> = null;
-                  }
-
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
                   <%= java_annotations(field) %>

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -286,6 +286,10 @@ public class <%= schema_name %> {
                       this.<%= escape_reserved_word(field.camelize_name) %> = <%= escape_reserved_word(field.camelize_name) %>;
                       return this;
                   }
+
+                  public void unSet<%= field.classify_name %>() {
+                      this.<%= escape_reserved_word(field.camelize_name) %> = null;
+                  }
                 <% end %>
                 <% type.optional_input_fields.each do |field| %>
                   <%= java_annotations(field) %>
@@ -299,7 +303,7 @@ public class <%= schema_name %> {
                       return this;
                   }
 
-                  public void clear<%= field.classify_name %>() {
+                  public void unSet<%= field.classify_name %>() {
                       this.<%= escape_reserved_word(field.camelize_name) %> = null;
                       this.<%= field.camelize_name %>Seen = false;
                   }

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -300,10 +300,11 @@ public class <%= schema_name %> {
                       return this;
                   }
 
-                  // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized
-                  public void unset<%= field.classify_name %>() {
+                  // Unsets the <%= escape_reserved_word(field.camelize_name) %> property so that it is not serialized.
+                  public <%= type.name %> unset<%= field.classify_name %>() {
                       this.<%= escape_reserved_word(field.camelize_name) %> = null;
                       this.<%= field.camelize_name %>Seen = false;
+                      return this;
                   }
 
                 <% end %>

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1100,7 +1100,8 @@ public class Generated {
             return this;
         }
 
-        public void unSetKey() {
+        // Unsets the key property so that it is not serialized
+        public void unsetKey() {
             this.key = null;
         }
 
@@ -1113,7 +1114,8 @@ public class Generated {
             return this;
         }
 
-        public void unSetValue() {
+        // Unsets the value property so that it is not serialized
+        public void unsetValue() {
             this.value = null;
         }
 
@@ -1128,7 +1130,8 @@ public class Generated {
             return this;
         }
 
-        public void unSetTtl() {
+        // Unsets the ttl property so that it is not serialized
+        public void unsetTtl() {
             this.ttl = null;
             this.ttlSeen = false;
         }
@@ -1144,7 +1147,8 @@ public class Generated {
             return this;
         }
 
-        public void unSetNegate() {
+        // Unsets the negate property so that it is not serialized
+        public void unsetNegate() {
             this.negate = null;
             this.negateSeen = false;
         }
@@ -1160,7 +1164,8 @@ public class Generated {
             return this;
         }
 
-        public void unSetApiClient() {
+        // Unsets the apiClient property so that it is not serialized
+        public void unsetApiClient() {
             this.apiClient = null;
             this.apiClientSeen = false;
         }

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1100,6 +1100,10 @@ public class Generated {
             return this;
         }
 
+        public void unSetKey() {
+            this.key = null;
+        }
+
         public int getValue() {
             return value;
         }
@@ -1107,6 +1111,10 @@ public class Generated {
         public SetIntegerInput setValue(int value) {
             this.value = value;
             return this;
+        }
+
+        public void unSetValue() {
+            this.value = null;
         }
 
         @Nullable
@@ -1120,7 +1128,7 @@ public class Generated {
             return this;
         }
 
-        public void clearTtl() {
+        public void unSetTtl() {
             this.ttl = null;
             this.ttlSeen = false;
         }
@@ -1136,7 +1144,7 @@ public class Generated {
             return this;
         }
 
-        public void clearNegate() {
+        public void unSetNegate() {
             this.negate = null;
             this.negateSeen = false;
         }
@@ -1152,7 +1160,7 @@ public class Generated {
             return this;
         }
 
-        public void clearApiClient() {
+        public void unSetApiClient() {
             this.apiClient = null;
             this.apiClientSeen = false;
         }

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1100,11 +1100,6 @@ public class Generated {
             return this;
         }
 
-        // Unsets the key property so that it is not serialized
-        public void unsetKey() {
-            this.key = null;
-        }
-
         public int getValue() {
             return value;
         }
@@ -1112,11 +1107,6 @@ public class Generated {
         public SetIntegerInput setValue(int value) {
             this.value = value;
             return this;
-        }
-
-        // Unsets the value property so that it is not serialized
-        public void unsetValue() {
-            this.value = null;
         }
 
         @Nullable

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1120,6 +1120,11 @@ public class Generated {
             return this;
         }
 
+        public void clearTtl() {
+            this.ttl = null;
+            this.ttlSeen = false;
+        }
+
         @Nullable
         public Boolean getNegate() {
             return negate;
@@ -1131,6 +1136,11 @@ public class Generated {
             return this;
         }
 
+        public void clearNegate() {
+            this.negate = null;
+            this.negateSeen = false;
+        }
+
         @Nullable
         public String getApiClient() {
             return apiClient;
@@ -1140,6 +1150,11 @@ public class Generated {
             this.apiClient = apiClient;
             this.apiClientSeen = true;
             return this;
+        }
+
+        public void clearApiClient() {
+            this.apiClient = null;
+            this.apiClientSeen = false;
         }
 
         public void appendTo(StringBuilder _queryBuilder) {

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1120,10 +1120,11 @@ public class Generated {
             return this;
         }
 
-        // Unsets the ttl property so that it is not serialized
-        public void unsetTtl() {
+        // Unsets the ttl property so that it is not serialized.
+        public SetIntegerInput unsetTtl() {
             this.ttl = null;
             this.ttlSeen = false;
+            return this;
         }
 
         @Nullable
@@ -1137,10 +1138,11 @@ public class Generated {
             return this;
         }
 
-        // Unsets the negate property so that it is not serialized
-        public void unsetNegate() {
+        // Unsets the negate property so that it is not serialized.
+        public SetIntegerInput unsetNegate() {
             this.negate = null;
             this.negateSeen = false;
+            return this;
         }
 
         @Nullable
@@ -1154,10 +1156,11 @@ public class Generated {
             return this;
         }
 
-        // Unsets the apiClient property so that it is not serialized
-        public void unsetApiClient() {
+        // Unsets the apiClient property so that it is not serialized.
+        public SetIntegerInput unsetApiClient() {
             this.apiClient = null;
             this.apiClientSeen = false;
+            return this;
         }
 
         public void appendTo(StringBuilder _queryBuilder) {

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -166,17 +166,17 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testUnSetRequiredlFieldOnInput() throws Exception {
+    public void testUnsetRequiredlFieldOnInput() throws Exception {
         String queryString = Generated.mutation(mutation -> mutation
-            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unSetValue())
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unsetValue())
         ).toString();
         assertEquals("mutation{set_integer(input:{key:\"answer\",ttl:null})}", queryString);
     }
 
     @Test
-    public void testUnSetOptionalFieldOnInput() throws Exception {
+    public void testUnsetOptionalFieldOnInput() throws Exception {
         String queryString = Generated.mutation(mutation -> mutation
-            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unSetTtl())
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unsetTtl())
         ).toString();
         assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
     }

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -166,9 +166,17 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testClearOptionalFieldOnInput() throws Exception {
+    public void testUnSetRequiredlFieldOnInput() throws Exception {
         String queryString = Generated.mutation(mutation -> mutation
-            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).clearTtl())
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unSetValue())
+        ).toString();
+        assertEquals("mutation{set_integer(input:{key:\"answer\",ttl:null})}", queryString);
+    }
+
+    @Test
+    public void testUnSetOptionalFieldOnInput() throws Exception {
+        String queryString = Generated.mutation(mutation -> mutation
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unSetTtl())
         ).toString();
         assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
     }

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -166,14 +166,6 @@ public class IntegrationTest {
     }
 
     @Test
-    public void testUnsetRequiredlFieldOnInput() throws Exception {
-        String queryString = Generated.mutation(mutation -> mutation
-            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unsetValue())
-        ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",ttl:null})}", queryString);
-    }
-
-    @Test
     public void testUnsetOptionalFieldOnInput() throws Exception {
         String queryString = Generated.mutation(mutation -> mutation
             .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).unsetTtl())

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -164,4 +164,12 @@ public class IntegrationTest {
         ).toString();
         assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:null})}", queryString);
     }
+
+    @Test
+    public void testClearOptionalFieldOnInput() throws Exception {
+        String queryString = Generated.mutation(mutation -> mutation
+            .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null).clearTtl())
+        ).toString();
+        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
+    }
 }


### PR DESCRIPTION
# This PR
In this PR I am adding a way to unset properties so that they aren't serialized. This change is required because currently there is no way to tell a property to not serialize. 
This is aimed to help consumers of this generator that were effected by the change #28 that used to reset their input types with `inputType.setProperty(null)` so that they can use `inputType.unsetProperty()` instead.

- [x] Generated supporting schema
- [x] Added tests
- [x] Change results in no API breakage