### PR TITLE
Add optional to Input class

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -299,7 +299,7 @@ public class <%= schema_name %> {
                   }
 
                   public <%= type.name %> set<%= field.classify_name %>(<%= java_annotations(field, in_argument: true) %><%= java_input_type(field.type) %> <%= escape_reserved_word(field.camelize_name) %>) {
-                      this.<%= escape_reserved_word(field.camelize_name) %> = Input.value(<%= escape_reserved_word(field.camelize_name) %>);
+                      this.<%= escape_reserved_word(field.camelize_name) %> = Input.optional(<%= escape_reserved_word(field.camelize_name) %>);
                       return this;
                   }
 

--- a/support/src/main/java/com/shopify/graphql/support/Input.java
+++ b/support/src/main/java/com/shopify/graphql/support/Input.java
@@ -15,6 +15,10 @@ public final class Input<T> implements Serializable {
     return new Input<>(value, true);
   }
 
+  public static <T> Input<T> optional(@Nullable T value) {
+    return value != null ? value(value) : Input.<T>undefined();
+  }
+
   public static <T> Input<T> undefined() {
     return new Input<>(null, false);
   }

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -1117,7 +1117,7 @@ public class Generated {
         }
 
         public SetIntegerInput setTtl(@Nullable LocalDateTime ttl) {
-            this.ttl = Input.value(ttl);
+            this.ttl = Input.optional(ttl);
             return this;
         }
 
@@ -1139,7 +1139,7 @@ public class Generated {
         }
 
         public SetIntegerInput setNegate(@Nullable Boolean negate) {
-            this.negate = Input.value(negate);
+            this.negate = Input.optional(negate);
             return this;
         }
 
@@ -1161,7 +1161,7 @@ public class Generated {
         }
 
         public SetIntegerInput setApiClient(@Nullable String apiClient) {
-            this.apiClient = Input.value(apiClient);
+            this.apiClient = Input.optional(apiClient);
             return this;
         }
 

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -163,7 +163,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
             .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:null})}", queryString);
+        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
     }
 
     @Test


### PR DESCRIPTION
This PR aims to add optional method to Input Class. All `setXYZ(null)` method with null value won't be serialized by default. In order to set null explicitly, please do `setXYZInput(Input.value(null))`.