### PR TITLE
Update build.gradle to use implementation over compile

### DIFF
--- a/support/build.gradle
+++ b/support/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'maven'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.7'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.code.gson:gson:2.7'
+    testImplementation 'junit:junit:4.12'
 }
 
 compileJava {


### PR DESCRIPTION
`compile` is deprecated, and will be removed at the end of 2018. Replaced it with `implementation` to remove the build warning.