### PR TITLE
Include deprecated types in toString and fromString

### DIFF
--- a/codegen/lib/graphql_java_gen/templates/Enum.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/Enum.java.erb
@@ -41,7 +41,7 @@ import java.util.Map;
             }
 
             switch (value) {
-              <% type.enum_values.each do |value| %>
+              <% type.enum_values(include_deprecated: include_deprecated).each do |value| %>
                 case "<%= value.name %>": {
                   return <%= value.upcase_name %>;
                 }
@@ -53,7 +53,7 @@ import java.util.Map;
           }
           public String toString() {
             switch (this) {
-              <% type.enum_values.each do |value| %>
+              <% type.enum_values(include_deprecated: include_deprecated).each do |value| %>
                 case <%= value.upcase_name %>: {
                   return "<%= value.name %>";
                 }


### PR DESCRIPTION
Not including these types in fromString and toString can actually cause pretty big problems. Our current issue was that in ResourceType, "Discounts" was deprecated in order to force us to start using "PriceRule". This is fine, but for two problems.

The first problem is that "Price_Rule" type causes an internal error server side, so we cant yet use it.
The second is that since "Discounts" has as a toString() return value of empty string, the appLinks and markettingActions which use the deprecated type generate an invalid query (see the type is empty):

> marketingActions(type:,location:INDEX){id,title,url,embedded,inContext,text,icon{src}}

This means we cannot load the discounts list on master.

The solution is adding deprecated items to the ToString function and for extra safety I made sure it could be pulled from the graphQL too.