### PR TITLE
Remove extra back ticks in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ You may also generate separate class files for each schema entity using the `sav
 In this case, you should provide the path to a directory, not a single class.
 
 e.g.
-```
 ```ruby
 require 'graphql_java_gen'
 require 'graphql_schema'


### PR DESCRIPTION
Came across this library(thank you) and saw something small to fix with the readme.