### PR TITLE
Update to current gradle api

### DIFF
--- a/support/build.gradle
+++ b/support/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'maven'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.8.5'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    testImplementation 'junit:junit:4.12'
 }
 
 compileJava {


### PR DESCRIPTION
Minor change to the gradle file

- compile is deprecated

https://medium.com/mindorks/implementation-vs-api-in-gradle-3-0-494c817a6fa