### PR TITLE
Fix java package version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The generated code depends on the com.shopify.graphql.support java
 package. This can be added to a gradle project by adding the following
 jCenter dependancy to you `build.gradle` file:
 
-    compile 'com.shopify.graphql.support:support:0.2.0'
+    compile 'com.shopify.graphql.support:support:0.1.1'
 
 ## Usage
 

--- a/codegen/lib/graphql_java_gen/version.rb
+++ b/codegen/lib/graphql_java_gen/version.rb
@@ -1,3 +1,3 @@
 class GraphQLJavaGen
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/support/graphql.java.gen.build.gradle
+++ b/support/graphql.java.gen.build.gradle
@@ -1,4 +1,4 @@
-def VERSION_NAME = '0.2.1'
+def VERSION_NAME = '0.1.1'
 
 buildscript {
     repositories {


### PR DESCRIPTION
Fixes #53
Closes #32

0.2.0 hasn't yet been released on [rubygems](https://rubygems.org/gems/graphql_java_gen) or [bintray](https://bintray.com/shopify/shopify-java/graphql-support).  The latest released version is 0.1.1, so I've updated the README accordingly.