### PR TITLE
Add support for publishing to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    environment:
+      name: Central Repository Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Publish package
+        working-directory: ./support
+        run: ./gradlew uploadArchives
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tmp/
 .idea
 /*.gem
+.gradle

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ And then execute:
 
 The generated code depends on the com.shopify.graphql.support java
 package. This can be added to a gradle project by adding the following
-jCenter dependancy to you `build.gradle` file:
+dependancy to you `build.gradle` file:
 
-    compile 'com.shopify.graphql.support:support:0.2.0'
+    implementation 'com.shopify.graphql.support:support:0.2.1'
 
 ## Usage
 

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,9 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        mavenCentral()
     }
 }
 

--- a/support/gradle/wrapper/gradle-wrapper.properties
+++ b/support/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/support/graphql.java.gen.build.gradle
+++ b/support/graphql.java.gen.build.gradle
@@ -1,18 +1,12 @@
 def VERSION_NAME = '0.2.0'
 
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
-
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'com.jfrog.bintray'
+apply plugin: 'signing'
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
@@ -34,8 +28,6 @@ test {
         exceptionFormat = 'full'
     }
 }
-
-version = VERSION_NAME
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
@@ -65,60 +57,65 @@ ext {
     licenseName = 'The MIT License'
     licenseUrl = 'https://opensource.org/licenses/MIT'
     allLicenses = ["MIT"]
+
+    author = 'Shopify Inc.'
 }
 
 group = publishedGroupId
+archivesBaseName = artifact
+version = VERSION_NAME
 
-install {
-    repositories.mavenInstaller {
-        // Generates POM.xml with proper parameters
-        pom {
-            project {
-                groupId publishedGroupId
-                artifactId artifact
-
-                name libraryName
-                description libraryDescription
-                url siteUrl
-
-                licenses {
-                    license {
-                        name licenseName
-                        url licenseUrl
-                    }
-                }
-
-                scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
-                }
-            }
-        }
-    }
+signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign configurations.archives
 }
 
-bintray {
-    /*
-    These values can be found on https://bintray.com/profile/edit
-    BINTRAY_USER : your personal profile name (from "Your Profile")
-    BINTRAY_KEY : found on the left menu, under "API Key"
-     */
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-    configurations = ['archives']
-    publish = true
-    pkg {
-        userOrg = 'shopify'
-        repo = 'shopify-java'
-        name = libraryName
-        desc = libraryDescription
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = allLicenses
-        version {
-            name = VERSION_NAME
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: System.getenv("OSSRH_USERNAME"), password: System.getenv("OSSRH_PASSWORD"))
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: System.getenv("OSSRH_USERNAME"), password: System.getenv("OSSRH_PASSWORD"))
+            }
+
+            pom {
+                project {
+                    groupId project.ext.publishedGroupId
+                    artifactId project.ext.artifact
+
+                    name project.ext.libraryName
+                    description project.ext.libraryDescription
+                    url project.ext.siteUrl
+
+                    developers {
+                        developer {
+                            name project.ext.author
+                        }
+                    }
+
+                    licenses {
+                        license {
+                        name project.ext.licenseName
+                        url project.ext.licenseUrl
+                        }
+                    }
+
+                    scm {
+                        connection = project.ext.gitUrl
+                        developerConnection = project.ext.gitUrl
+                        url = project.ext.siteUrl
+                    }
+                }
+            }
         }
     }
 }

--- a/support/graphql.java.gen.build.gradle
+++ b/support/graphql.java.gen.build.gradle
@@ -1,4 +1,4 @@
-def VERSION_NAME = '0.2.0'
+def VERSION_NAME = '0.2.1'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
JFrog has shutdown Bintray and JCenter. See announcement [here](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

This PR removes the Bintray plugin and adds a GitHub action for automated publishing to OSSRH staging repository (promotion to Maven Central will require manual confirmation).

I've also bumped the patch version to reflect this is a rebuild of `0.2.0` but hosted on a new repository.

See https://github.com/Shopify/graphql_java_gen/runs/2464072449?check_suite_focus=true for an example of the Github action in... _action_.

