### PR TITLE
Support Query & Mutation Directives

### DIFF
--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -301,6 +301,14 @@ class GraphQLJavaGen
     expressions.join(', ')
   end
 
+  def java_directive_required_arg_defs(directive)
+    defs = []
+    directive.required_args.each do |arg|
+      defs << "#{java_input_type(arg.type)} #{escape_reserved_word(arg.camelize_name)}"
+    end
+    defs.join(', ')
+  end
+
   def java_implements(type)
     return "implements #{type.name} " unless type.object?
     interfaces = abstract_types.fetch(type.name)
@@ -352,7 +360,7 @@ class GraphQLJavaGen
         doc << "\n*"
         doc << "\n*"
       else
-        doc << '*'        
+        doc << '*'
       end
       doc << ' @deprecated '
       doc << element.deprecation_reason

--- a/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
+++ b/codegen/lib/graphql_java_gen/templates/APISchema.java.erb
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.shopify.graphql.support.AbstractResponse;
 import com.shopify.graphql.support.Arguments;
+import com.shopify.graphql.support.Directive;
 import com.shopify.graphql.support.Error;
 import com.shopify.graphql.support.Query;
 import com.shopify.graphql.support.SchemaViolationError;
@@ -18,9 +19,7 @@ import com.shopify.graphql.support.Input;
 <% end %>
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class <%= schema_name %> {
     public static final String API_VERSION = "<%= version %>";
@@ -28,11 +27,19 @@ public class <%= schema_name %> {
     <% [[:query, schema.query_root_name], [:mutation, schema.mutation_root_name]].each do |operation_type, root_name| %>
         <% next unless root_name %>
         public static <%= root_name %>Query <%= operation_type %>(<%= root_name %>QueryDefinition queryDef) {
-            StringBuilder queryString = new StringBuilder("<%= operation_type unless operation_type == :query %>{");
-            <%= root_name %>Query query = new <%= root_name %>Query(queryString);
-            queryDef.define(query);
-            queryString.append('}');
-            return query;
+            return <%= operation_type %>(Collections.emptyList(), queryDef);
+        }
+
+        public static <%= root_name %>Query <%= operation_type %>(List<Directive> directives, <%= root_name %>QueryDefinition queryDef) {
+          StringBuilder queryString = new StringBuilder("<%= operation_type %>");
+          for (Directive directive : directives) {
+            queryString.append(" " + directive.toString());
+          }
+          queryString.append(" {");
+          <%= root_name %>Query query = new <%= root_name %>Query(queryString);
+          queryDef.define(query);
+          queryString.append('}');
+          return query;
         }
 
         public static class <%= operation_type.capitalize %>Response {
@@ -66,6 +73,38 @@ public class <%= schema_name %> {
                 return new <%= operation_type.capitalize %>Response(response);
             }
         }
+    <% end %>
+
+    <% schema.directives.select { |directive| !(directive.locations & %w{QUERY MUTATION}).empty? }.each do |directive| %>
+      <%= java_doc(directive) %>
+      public static class <%= directive.classify_name %>Directive extends Directive {
+        <% directive.args.each do |arg| %>
+          public <%= java_input_type(arg.type) %> <%= escape_reserved_word(arg.camelize_name) %>;
+        <% end %>
+
+        public <%= directive.classify_name %>Directive(<%= java_directive_required_arg_defs(directive) %>) {
+          super("<%= directive.name %>");
+        }
+
+        <% unless directive.args.empty? %>
+          @Override
+          public String toString() {
+            StringBuilder _queryBuilder = new StringBuilder(super.toString());
+            _queryBuilder.append("(");
+            <% first_arg = true %>
+            <% directive.args.each do |arg| %>
+              if (<%= escape_reserved_word(arg.camelize_name) %> != null) {
+                <% unless first_arg %>_queryBuilder.append(", ");<% end %>
+                _queryBuilder.append("<%= arg.name %>:");
+                <%= generate_build_input_code(escape_reserved_word(arg.camelize_name), arg.type) %>
+              }
+              <% first_arg = false %>
+            <% end %>
+            _queryBuilder.append(")");
+            return _queryBuilder.toString();
+          }
+        <% end %>
+      }
     <% end %>
 
     <% schema.types.reject{ |type| type.name.start_with?('__') || type.scalar? }.each do |type| %>

--- a/graphql_java_gen.gemspec
+++ b/graphql_java_gen.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "graphql_schema", "~> 0.1.1"
+  spec.add_dependency "graphql_schema", "~> 0.1.8"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/support/src/main/java/com/shopify/graphql/support/Directive.java
+++ b/support/src/main/java/com/shopify/graphql/support/Directive.java
@@ -1,0 +1,14 @@
+package com.shopify.graphql.support;
+
+public abstract class Directive {
+    private final String name;
+
+    protected Directive(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "@" + name;
+    }
+}

--- a/support/src/test/java/com/shopify/graphql/support/DirectiveTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/DirectiveTest.java
@@ -1,0 +1,13 @@
+package com.shopify.graphql.support;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class DirectiveTest {
+    @Test
+    public void testName() {
+        Generated.SampleDirective directive = new Generated.SampleDirective();
+        assertEquals("@sample", directive.toString());
+    }
+}

--- a/support/src/test/java/com/shopify/graphql/support/Generated.java
+++ b/support/src/test/java/com/shopify/graphql/support/Generated.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -29,11 +30,25 @@ public class Generated {
     public static final String API_VERSION = "2020-01";
 
     public static QueryRootQuery query(QueryRootQueryDefinition queryDef) {
-        StringBuilder queryString = new StringBuilder("{");
+        return query(Collections.emptyList(), queryDef);
+    }
+
+    public static QueryRootQuery query(List<Directive> directives, QueryRootQueryDefinition queryDef) {
+        StringBuilder queryString = new StringBuilder("query");
+        for (Directive directive : directives) {
+            queryString.append(" " + directive.toString());
+        }
+        queryString.append(" {");
         QueryRootQuery query = new QueryRootQuery(queryString);
         queryDef.define(query);
         queryString.append('}');
         return query;
+    }
+
+    public static class SampleDirective extends Directive {
+        SampleDirective() {
+            super("sample");
+        }
     }
 
     public static class QueryResponse {
@@ -69,7 +84,15 @@ public class Generated {
     }
 
     public static MutationQuery mutation(MutationQueryDefinition queryDef) {
-        StringBuilder queryString = new StringBuilder("mutation{");
+        return mutation(Collections.emptyList(), queryDef);
+    }
+
+    public static MutationQuery mutation(List<Directive> directives, MutationQueryDefinition queryDef) {
+        StringBuilder queryString = new StringBuilder("mutation");
+        for (Directive directive : directives) {
+            queryString.append(" " + directive.toString());
+        }
+        queryString.append(" {");
         MutationQuery query = new MutationQuery(queryString);
         queryDef.define(query);
         queryString.append('}');

--- a/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
+++ b/support/src/test/java/com/shopify/graphql/support/IntegrationTest.java
@@ -1,7 +1,10 @@
 package com.shopify.graphql.support;
 
+import junit.framework.Assert;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -20,13 +23,13 @@ public class IntegrationTest {
     @Test
     public void testRequiredArgQuery() throws Exception {
         String queryString = Generated.query(query -> query.string("user:1:name")).toString();
-        assertEquals("{string(key:\"user:1:name\")}", queryString);
+        assertEquals("query {string(key:\"user:1:name\")}", queryString);
     }
 
     @Test
     public void testOptionalArgQuery() throws Exception {
         String queryString = Generated.query(query -> query.keys(10, args -> args.after("cursor"))).toString();
-        assertEquals("{keys(first:10,after:\"cursor\")}", queryString);
+        assertEquals("query {keys(first:10,after:\"cursor\")}", queryString);
     }
 
     @Test
@@ -37,7 +40,7 @@ public class IntegrationTest {
                 .onStringEntry(strEntry -> strEntry.value())
             )
         ).toString();
-        assertEquals("{entry(key:\"user:1\"){__typename,ttl,... on StringEntry{value}}}", queryString);
+        assertEquals("query {entry(key:\"user:1\"){__typename,ttl,... on StringEntry{value}}}", queryString);
     }
 
     @Test
@@ -47,7 +50,7 @@ public class IntegrationTest {
                 .onStringEntry(strEntry -> strEntry.value())
             )
         ).toString();
-        assertEquals("{entry_union(key:\"user:1\"){__typename,... on StringEntry{value}}}", queryString);
+        assertEquals("query {entry_union(key:\"user:1\"){__typename,... on StringEntry{value}}}", queryString);
     }
 
     @Test
@@ -55,13 +58,13 @@ public class IntegrationTest {
         String queryString = Generated.query(query -> query
             .keys(10, args -> args.type(Generated.KeyType.INTEGER))
         ).toString();
-        assertEquals("{keys(first:10,type:INTEGER)}", queryString);
+        assertEquals("query {keys(first:10,type:INTEGER)}", queryString);
     }
 
     @Test
     public void testMutation() throws Exception {
         String queryString = Generated.mutation(mutation -> mutation.setString("foo", "bar")).toString();
-        assertEquals("mutation{set_string(key:\"foo\",value:\"bar\")}", queryString);
+        assertEquals("mutation {set_string(key:\"foo\",value:\"bar\")}", queryString);
     }
 
     @Test
@@ -69,7 +72,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
             .setInteger(new Generated.SetIntegerInput("answer", 42).setNegate(true))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,negate:true})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42,negate:true})}", queryString);
     }
 
     @Test
@@ -78,7 +81,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
             .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(ttl))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48\"})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48\"})}", queryString);
     }
 
     @Test
@@ -163,7 +166,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
             .setInteger(new Generated.SetIntegerInput("answer", 42).setTtl(null))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42})}", queryString);
     }
 
     @Test
@@ -171,7 +174,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
           .setInteger(new Generated.SetIntegerInput("answer", 42).setTtlInput(Input.<LocalDateTime>undefined()))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42})}", queryString);
     }
 
     @Test
@@ -179,7 +182,7 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
           .setInteger(new Generated.SetIntegerInput("answer", 42).setTtlInput(Input.<LocalDateTime>value(null)))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:null})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42,ttl:null})}", queryString);
     }
 
     @Test
@@ -187,6 +190,14 @@ public class IntegrationTest {
         String queryString = Generated.mutation(mutation -> mutation
           .setInteger(new Generated.SetIntegerInput("answer", 42).setTtlInput(Input.<LocalDateTime>value(LocalDateTime.of(2017, 1, 31, 10, 9, 48))))
         ).toString();
-        assertEquals("mutation{set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48\"})}", queryString);
+        assertEquals("mutation {set_integer(input:{key:\"answer\",value:42,ttl:\"2017-01-31T10:09:48\"})}", queryString);
+    }
+
+    @Test
+    public void testQueryWithDirectives() {
+        List<Directive> directives = new ArrayList<>();
+        directives.add(new Generated.SampleDirective());
+        Generated.QueryRootQuery query = Generated.query(directives, root -> root.integer("productCount"));
+        Assert.assertEquals("query @sample {integer(key:\"productCount\")}", query.toString());
     }
 }


### PR DESCRIPTION
This PR modifies the tool to add support for generating `QUERY` and `MUTATION` directives.

### Summary of Changes

- Adds abstract `Directive` class.
- Modifies `APISchema.java.erb` template to generate overloaded versions of the `query` and `mutation` methods that accept a `List<Directive>`.
- Modifies the default query and mutation serialization to ensure it is prefixed with the operation type.

### Generated Example
```java
/**
* An example directive.
*/
public static class MyDirective extends Directive {
    public AnEnumeratedArgument myArgument;

    public MyDirective() {
        super("myDirective");
    }

    @Override
    public String toString() {
        StringBuilder _queryBuilder = new StringBuilder(super.toString());
        _queryBuilder.append("(");

        if (myArgument != null) {
            _queryBuilder.append("myArgument:");
            _queryBuilder.append(myArgument.toString());
        }

        _queryBuilder.append(")");
        return _queryBuilder.toString();
    }
}
```