### PR TITLE
Update graphql_java_gen.rb warnning was fixed in the new version

### DIFF
--- a/codegen/lib/graphql_java_gen.rb
+++ b/codegen/lib/graphql_java_gen.rb
@@ -47,7 +47,7 @@ class GraphQLJavaGen
     private
 
     def erb_for(template_filename)
-      erb = ERB.new(File.read(template_filename), nil, '-')
+      erb = ERB.new(File.read(template_filename), trim_mode: '-')
       erb.filename = template_filename
       erb
     end
@@ -58,7 +58,7 @@ class GraphQLJavaGen
 
   def erb_for_entity(template)
     template_filename = File.expand_path("../graphql_java_gen/templates/#{template}.erb", __FILE__)
-    erb = ERB.new(File.read(template_filename), nil, '-')
+    erb = ERB.new(File.read(template_filename), trim_mode: '-')
     erb.filename = template_filename
     erb
   end


### PR DESCRIPTION
Fixed: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.